### PR TITLE
Feature #123 Keycloak Integration

### DIFF
--- a/gendox-core-api/pom.xml
+++ b/gendox-core-api/pom.xml
@@ -274,6 +274,20 @@
             <version>1.12.568</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.keycloak/keycloak-admin-client -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <version>22.0.4</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.keycloak/keycloak-core -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>22.0.4</version>
+        </dependency>
+
 
 
 

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/AuthenticationService.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/AuthenticationService.java
@@ -1,0 +1,30 @@
+package dev.ctrlspace.gendox.authentication;
+
+import dev.ctrlspace.gendox.gendoxcoreapi.exceptions.GendoxException;
+import dev.ctrlspace.gendox.gendoxcoreapi.model.User;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface for the Authentication Service.
+ * This service is used to authenticate users and clients.
+ * It is important all different Authentication Services (like Keycloak, LDAP, auth0, etc.) implement this interface.
+ * This way, the rest of the application can use the same methods to authenticate users and clients, regardless of the
+ * authentication server used.
+ *
+ */
+public interface AuthenticationService {
+
+
+    /**
+     * This method is used to get an access token for the specified Client.
+     *
+     * @return
+     */
+    public Jwt getClientToken(String clientId, String clientSecret);
+
+    public Jwt impersonateUser(String username);
+
+    String createUser(User user, @Nullable String password, boolean emailVerified, boolean tempPassword) throws GendoxException;
+}

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/GendoxAuthenticationToken.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/GendoxAuthenticationToken.java
@@ -1,0 +1,44 @@
+package dev.ctrlspace.gendox.authentication;
+
+import dev.ctrlspace.gendox.gendoxcoreapi.model.authentication.UserProfile;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Collection;
+
+/**
+ * This class is used to store the user profile and the original JWT token.
+ * The default IDP is Keycloak with OIDC.
+ *
+ */
+public class GendoxAuthenticationToken extends AbstractAuthenticationToken {
+    private UserProfile userProfile;
+    private Jwt jwt;
+
+    public GendoxAuthenticationToken(UserProfile userProfile, Jwt jwt, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.userProfile = userProfile;
+        this.jwt = jwt;
+        setAuthenticated(true); // must use super, as we override the method
+
+    }
+
+    public GendoxAuthenticationToken(Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return jwt.getTokenValue();
+    }
+
+    @Override
+    public UserProfile getPrincipal() {
+        return userProfile;
+    }
+
+    public Jwt getJwt() {
+        return jwt;
+    }
+}

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/GendoxJwtAuthenticationConverter.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/GendoxJwtAuthenticationConverter.java
@@ -1,0 +1,52 @@
+package dev.ctrlspace.gendox.authentication;
+
+import dev.ctrlspace.gendox.gendoxcoreapi.converters.JwtDTOUserProfileConverter;
+import dev.ctrlspace.gendox.gendoxcoreapi.model.authentication.JwtDTO;
+import dev.ctrlspace.gendox.gendoxcoreapi.model.authentication.UserProfile;
+import dev.ctrlspace.gendox.gendoxcoreapi.services.UserService;
+import dev.ctrlspace.gendox.gendoxcoreapi.utils.JWTUtils;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+@Component
+public class GendoxJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private UserService userService;
+    private JWTUtils jwtUtils;
+    private JwtDTOUserProfileConverter jwtDTOUserProfileConverter;
+
+
+    @Autowired
+    public GendoxJwtAuthenticationConverter(UserService userService, JwtDTOUserProfileConverter jwtDTOUserProfileConverter, JWTUtils jwtUtils) {
+        this.userService = userService;
+        this.jwtDTOUserProfileConverter = jwtDTOUserProfileConverter;
+        this.jwtUtils = jwtUtils;
+    }
+
+
+    @SneakyThrows
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+
+        // Extract additional information to populate CustomUserDetails
+        String email = jwt.getClaimAsString("preferred_username");
+        UserProfile userProfile = userService.getUserProfileByUniqueIdentifier(email);
+        JwtDTO jwtDTO = jwtDTOUserProfileConverter.jwtDTO(userProfile);
+        var authorities = jwtUtils.getAuthorities(jwtDTO).stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+
+
+        return new GendoxAuthenticationToken(userProfile, jwt, authorities);
+    }
+
+    @Override
+    public <U> Converter<Jwt, U> andThen(Converter<? super AbstractAuthenticationToken, ? extends U> after) {
+        return Converter.super.andThen(after);
+    }
+}

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/KeycloakAuthenticationService.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/authentication/KeycloakAuthenticationService.java
@@ -1,0 +1,193 @@
+package dev.ctrlspace.gendox.authentication;
+
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
+import dev.ctrlspace.gendox.gendoxcoreapi.exceptions.GendoxException;
+import dev.ctrlspace.gendox.gendoxcoreapi.model.User;
+import jakarta.ws.rs.core.Response;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.CreatedResponseUtil;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.Nullable;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
+
+@Component
+public class KeycloakAuthenticationService implements AuthenticationService {
+
+    private Logger logger = LoggerFactory.getLogger(KeycloakAuthenticationService.class);
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    private String keycloakServerUrl;
+
+    private String keycloakTokenUrl;
+
+    private String realm;
+
+    private String clientId;
+
+    private String clientSecret;
+
+    private Keycloak keycloakClient;
+
+
+    public KeycloakAuthenticationService(@Value("${keycloak.base-url}") String keycloakServerUrl,
+                                         @Value("${keycloak.token-uri}") String keycloakTokenUrl,
+                                         @Value("${keycloak.realm}") String realm,
+                                         @Value("${keycloak.client-id}") String clientId,
+                                         @Value("${keycloak.client-secret}") String clientSecret) {
+
+        this.keycloakServerUrl = keycloakServerUrl;
+        this.keycloakTokenUrl = keycloakTokenUrl;
+        this.realm = realm;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+
+        keycloakClient = KeycloakBuilder.builder()
+                .serverUrl(keycloakServerUrl)
+                .realm(realm)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build();
+    }
+
+    @Override
+    public Jwt getClientToken(String clientId, String clientSecret) {
+        return null;
+    }
+
+    @Override
+    public Jwt impersonateUser(String username) {
+
+        AccessTokenResponse clientToken = keycloakClient.tokenManager().getAccessToken();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("grant_type", OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
+        map.add("client_id", clientId);
+        map.add("client_secret", clientSecret);
+        map.add("subject_token", clientToken.getToken());
+        map.add("requested_subject", username);
+        map.add("requested_token_type", OAuth2Constants.ACCESS_TOKEN_TYPE);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
+
+
+        ResponseEntity<AccessTokenResponse> impersonationToken = restTemplate.postForEntity(
+                keycloakTokenUrl,
+                request,
+                AccessTokenResponse.class);
+
+        String tokenString = impersonationToken.getBody().getToken();
+        // Parse the JWT token
+        SignedJWT signedJWT = null;
+        try {
+            signedJWT = (SignedJWT) JWTParser.parse(tokenString);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Extract headers and claims
+        JWSHeader jwtHeaders = signedJWT.getHeader();
+        Payload payload = signedJWT.getPayload();
+
+
+        // Convert Unix timestamps to Instant
+        Map<String, Object> claims = payload.toJSONObject();
+        convertTimestampsToInstant(claims);
+
+        // Rebuild the token using Spring Boot's Jwt class
+        Jwt jwt = Jwt.withTokenValue(tokenString)
+                .headers(h -> h.putAll(jwtHeaders.toJSONObject()))
+                .claims(c -> c.putAll(claims))
+                .build();
+
+
+        return jwt;
+
+    }
+
+    private void convertTimestampsToInstant(Map<String, Object> claims) {
+        convertToInstant(claims, "exp");
+        convertToInstant(claims, "iat");
+        convertToInstant(claims, "nbf");
+    }
+
+    private void convertToInstant(Map<String, Object> claims, String claimKey) {
+        if (claims.containsKey(claimKey)) {
+            Object timestamp = claims.get(claimKey);
+            if (timestamp instanceof Long) {
+                Instant instant = Instant.ofEpochSecond((Long) timestamp);
+                claims.put(claimKey, instant);
+            }
+        }
+    }
+    @Override
+    public String createUser(User user, @Nullable String password, boolean emailVerified, boolean tempPassword) throws GendoxException {
+        String username = user.getEmail();
+        if (username == null) {
+            username = user.getUserName();
+        }
+        UserRepresentation userRepresentation = new UserRepresentation();
+        userRepresentation.setUsername(username);
+        userRepresentation.setFirstName(user.getFirstName());
+        userRepresentation.setLastName(user.getLastName());
+        userRepresentation.setEmail(user.getEmail());
+        userRepresentation.setEnabled(true);
+        userRepresentation.setEmailVerified(emailVerified);
+        if (!emailVerified) {
+            userRepresentation.setRequiredActions(Arrays.asList("VERIFY_EMAIL"));
+        }
+
+        if (password != null) {
+            CredentialRepresentation credential = new CredentialRepresentation();
+            credential.setTemporary(tempPassword);
+            credential.setType(CredentialRepresentation.PASSWORD);
+            credential.setValue(password);
+            userRepresentation.setCredentials(Arrays.asList(credential));
+        }
+
+        Response response = keycloakClient.realm(realm)
+                .users()
+                .create(userRepresentation);
+
+        if (response.getStatus() != 201) {
+            logger.error("Keycloak create user error " + response.getStatusInfo().getReasonPhrase());
+            throw new GendoxException("CREATE_USER_ERROR", "An error occurred while creating user", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        String userId = CreatedResponseUtil.getCreatedId(response);
+        UserResource createdUser = keycloakClient.realm(realm).users().get(userId);
+
+
+        if (!emailVerified) {
+            createdUser.sendVerifyEmail();
+        }
+        if (tempPassword) {
+            createdUser.resetPasswordEmail();
+        }
+
+        return userId;
+    }
+}

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/configuration/GendoxCoreApiApplication.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/configuration/GendoxCoreApiApplication.java
@@ -1,5 +1,6 @@
 package dev.ctrlspace.gendox.gendoxcoreapi.configuration;
 
+import dev.ctrlspace.gendox.authentication.GendoxJwtAuthenticationConverter;
 import dev.ctrlspace.gendox.spring.batch.jobs.SpringBatchConfiguration;
 import dev.ctrlspace.gendox.gendoxcoreapi.ai.engine.services.openai.aiengine.aiengine.AiModelService;
 import dev.ctrlspace.gendox.gendoxcoreapi.controller.UserController;
@@ -23,7 +24,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-import java.lang.reflect.Method;
 import java.util.StringJoiner;
 
 @SpringBootApplication
@@ -40,6 +40,7 @@ import java.util.StringJoiner;
         SpringBatchConfiguration.class,
         LoggingObservationHandler.class,
         SpringBatchConfiguration.class,
+        GendoxJwtAuthenticationConverter.class,
         })
 @EnableCaching
 @EnableJpaRepositories(basePackageClasses = {UserRepository.class})

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/configuration/SecurityConfiguration.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/configuration/SecurityConfiguration.java
@@ -1,48 +1,24 @@
 package dev.ctrlspace.gendox.gendoxcoreapi.configuration;
 
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.jwk.source.JWKSource;
-import com.nimbusds.jose.proc.SecurityContext;
-import dev.ctrlspace.gendox.gendoxcoreapi.services.UserService;
+import dev.ctrlspace.gendox.authentication.GendoxJwtAuthenticationConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
-import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-import java.text.ParseException;
-import java.util.stream.Collectors;
 
 @Configuration
 @EnableMethodSecurity(prePostEnabled = true, securedEnabled = true)
@@ -50,6 +26,9 @@ public class SecurityConfiguration {
 
     @Value("${rsa.private-key}")
     private String privateKeyPath;
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
+    private String jwkSetUri;
 
     @Autowired
     private ResourceLoader resourceLoader;
@@ -75,10 +54,9 @@ public class SecurityConfiguration {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
-                                           DaoAuthenticationProvider daoAuthenticationProvider,
-                                           CorsConfigurationSource corsConfigurationSource,
                                            JwtDecoder jwtDecoder,
-                                           JwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
+                                           GendoxJwtAuthenticationConverter gendoxJwtAuthenticationConverter,
+                                           CorsConfigurationSource corsConfigurationSource) throws Exception {
 
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
@@ -99,81 +77,94 @@ public class SecurityConfiguration {
                                 .anyRequest().authenticated()
                 )
                 .exceptionHandling(httpExConfigurer -> httpExConfigurer.authenticationEntryPoint(authEntryPoint))
-                .httpBasic(Customizer.withDefaults())
-                .authenticationProvider(daoAuthenticationProvider)
+//                .httpBasic(Customizer.withDefaults())
+//                .authenticationProvider(daoAuthenticationProvider)
                 .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .oauth2ResourceServer(oauth2 ->
-                        oauth2.jwt(jwt -> {
-                            jwt.decoder(jwtDecoder);
-                            jwt.jwtAuthenticationConverter(jwtAuthenticationConverter);
-                        }));
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+//                .oauth2ResourceServer(oauth2 ->
+//                        oauth2.jwt(jwt -> {
+//                            jwt.decoder(jwtDecoder);
+//                            jwt.jwtAuthenticationConverter(jwtAuthenticationConverter);
+//                        }));
+
+
+        http.oauth2ResourceServer(oauth2 ->
+                oauth2.jwt(jwt -> {
+                    jwt.decoder(jwtDecoder);
+                    jwt.jwtAuthenticationConverter(gendoxJwtAuthenticationConverter);
+
+                }));
 
         return http.build();
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return NoOpPasswordEncoder.getInstance();
-    }
+//    @Bean
+//    public PasswordEncoder passwordEncoder() {
+//        return NoOpPasswordEncoder.getInstance();
+//    }
+//
+//    @Bean
+//    public AuthenticationProvider daoAuthenticationProvider(PasswordEncoder passwordEncoder, UserService userDetailsService) {
+//        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+//        provider.setPasswordEncoder(passwordEncoder);
+//        provider.setUserDetailsService(userDetailsService);
+//        return provider;
+//    }
+//
+//    @Bean
+//    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+//        // Customize the converter here
+//        JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+//        jwtGrantedAuthoritiesConverter.setAuthorityPrefix(""); // removes the default SCOPE_ prefix
+//
+//        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+//        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter);
+//
+//        return jwtAuthenticationConverter;
+//
+//    }
+//
+//    @Bean
+//    public JWK gendoxJwk() throws IOException, JOSEException, NoSuchAlgorithmException, ParseException, InvalidKeySpecException {
+//        Resource resource = resourceLoader.getResource(privateKeyPath);
+//        String privateKey = null;
+//        try (InputStream inputStream = resource.getInputStream();
+//             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+//            privateKey = reader.lines()
+//                    .collect(Collectors.joining(System.lineSeparator()));
+//        }
+//
+//        JWK jwk = JWK.parseFromPEMEncodedObjects(privateKey);
+//
+//        // Convert the public key string to an RSAPublicKey object
+//        return jwk;
+//    }
+//
+//    @Bean
+//    public RSAKey gendoxRsaKey(JWK gendoxJwk) {
+//        return gendoxJwk.toRSAKey();
+//    }
+//
+//    @Bean
+//    public JWKSource<SecurityContext> gendoxJwkSource(RSAKey gendoxRsaKey) {
+//        return (jwkSelector, securityContext) -> jwkSelector.select(new JWKSet(gendoxRsaKey));
+//    }
+//
+//
+//    @Bean
+//    public JwtDecoder gendoxJwtDecoder(@Qualifier("gendoxRsaKey") RSAKey rsaKey) throws JOSEException {
+//        return NimbusJwtDecoder.withPublicKey(rsaKey.toRSAPublicKey()).build();
+//    }
 
     @Bean
-    public AuthenticationProvider daoAuthenticationProvider(PasswordEncoder passwordEncoder, UserService userDetailsService) {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setPasswordEncoder(passwordEncoder);
-        provider.setUserDetailsService(userDetailsService);
-        return provider;
+    public JwtDecoder jwtDecoder() throws JOSEException {
+        return NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
     }
 
-    @Bean
-    public JwtAuthenticationConverter jwtAuthenticationConverter() {
-        // Customize the converter here
-        JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
-        jwtGrantedAuthoritiesConverter.setAuthorityPrefix(""); // removes the default SCOPE_ prefix
-
-        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
-        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter);
-
-        return jwtAuthenticationConverter;
-
-    }
-
-    @Bean
-    public JWK jwk() throws IOException, JOSEException, NoSuchAlgorithmException, ParseException, InvalidKeySpecException {
-        Resource resource = resourceLoader.getResource(privateKeyPath);
-        String privateKey = null;
-        try (InputStream inputStream = resource.getInputStream();
-             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-            privateKey = reader.lines()
-                    .collect(Collectors.joining(System.lineSeparator()));
-        }
-
-        JWK jwk = JWK.parseFromPEMEncodedObjects(privateKey);
-
-        // Convert the public key string to an RSAPublicKey object
-        return jwk;
-    }
-
-    @Bean
-    public RSAKey rsaKey(JWK jwk) {
-        return jwk.toRSAKey();
-    }
-
-    @Bean
-    public JWKSource<SecurityContext> jwkSource(RSAKey rsaKey) {
-        return (jwkSelector, securityContext) -> jwkSelector.select(new JWKSet(rsaKey));
-    }
-
-
-    @Bean
-    public JwtDecoder jwtDecoder(RSAKey rsaKey) throws JOSEException {
-        return NimbusJwtDecoder.withPublicKey(rsaKey.toRSAPublicKey()).build();
-    }
-
-    @Bean
-    public JwtEncoder jwtEncoder(JWKSource<SecurityContext> jwkSource) throws JOSEException {
-        return new NimbusJwtEncoder(jwkSource);
-    }
+//    @Bean
+//    public JwtEncoder gendoxJwtEncoder(JWKSource<SecurityContext> jwkSource) throws JOSEException {
+//        return new NimbusJwtEncoder(jwkSource);
+//    }
 
 
 }

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/controller/OrganizationController.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/controller/OrganizationController.java
@@ -39,19 +39,16 @@ public class OrganizationController {
 
     private OrganizationService organizationService;
     private UserOrganizationService userOrganizationService;
-    private JwtEncoder jwtEncoder;
     private OrganizationConverter organizationConverter;
     private JWTUtils jwtUtils;
 
 
     @Autowired
     public OrganizationController(OrganizationService organizationService,
-                                  JwtEncoder jwtEncoder,
                                   JWTUtils jwtUtils,
                                   UserOrganizationService userOrganizationService,
                                   OrganizationConverter organizationConverter) {
         this.organizationService = organizationService;
-        this.jwtEncoder = jwtEncoder;
         this.organizationConverter = organizationConverter;
         this.userOrganizationService = userOrganizationService;
         this.jwtUtils = jwtUtils;

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/controller/UserController.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/controller/UserController.java
@@ -3,14 +3,12 @@ package dev.ctrlspace.gendox.gendoxcoreapi.controller;
 import dev.ctrlspace.gendox.gendoxcoreapi.converters.UserConverter;
 import dev.ctrlspace.gendox.gendoxcoreapi.converters.UserProfileConverter;
 import dev.ctrlspace.gendox.gendoxcoreapi.exceptions.GendoxException;
-import dev.ctrlspace.gendox.gendoxcoreapi.model.Project;
 import dev.ctrlspace.gendox.gendoxcoreapi.model.User;
 import dev.ctrlspace.gendox.gendoxcoreapi.model.authentication.UserProfile;
 import dev.ctrlspace.gendox.gendoxcoreapi.model.dtos.UserDTO;
-import dev.ctrlspace.gendox.gendoxcoreapi.model.dtos.criteria.ProjectCriteria;
 import dev.ctrlspace.gendox.gendoxcoreapi.model.dtos.criteria.UserCriteria;
-import dev.ctrlspace.gendox.gendoxcoreapi.services.ProjectService;
 import dev.ctrlspace.gendox.gendoxcoreapi.services.UserService;
+import dev.ctrlspace.gendox.gendoxcoreapi.utils.JWTUtils;
 import dev.ctrlspace.gendox.gendoxcoreapi.utils.constants.ObservabilityTags;
 import io.micrometer.observation.annotation.Observed;
 import jakarta.validation.Valid;
@@ -18,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -29,8 +26,6 @@ import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -42,17 +37,17 @@ public class UserController {
 
     //    @Autowired
     private UserService userService;
-    private JwtEncoder jwtEncoder;
+    private JWTUtils jwtUtils;
     private UserProfileConverter userProfileConverter;
     private UserConverter userConverter;
 
     @Autowired
     public UserController(UserService userService,
-                          JwtEncoder jwtEncoder,
+                          JWTUtils jwtUtils,
                           UserProfileConverter userProfileConverter,
                           UserConverter userConverter) {
         this.userService = userService;
-        this.jwtEncoder = jwtEncoder;
+        this.jwtUtils = jwtUtils;
         this.userProfileConverter = userProfileConverter;
         this.userConverter = userConverter;
     }
@@ -96,24 +91,24 @@ public class UserController {
     }
 
     // TODO this is just for demo purposes, need to be rewrite
-    @GetMapping("/users/login")
-    @Operation(summary = "Get users token by email or user name",
-            description = "Retrieve user information based on their email address or username. " +
-                    "This method decodes the user's JWT based on the provided email or username " +
-                    "and returns a JWTResponse containing the user's JWT token.")
-    @Observed(name = "user.login",
-            contextualName = "user-login-method",
-            lowCardinalityKeyValues = {
-                    ObservabilityTags.LOGGABLE, "true",
-            })
-    public JwtResponse getUserByLogin(@RequestParam("userIdentifier") String userIdentifier) throws Exception {
-
-        // run code to get the user from the database
-        JwtClaimsSet claims = userService.getJwtClaims(userIdentifier);
-
-        String jwt = jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
-        return new JwtResponse(jwt);
-    }
+//    @GetMapping("/users/login")
+//    @Operation(summary = "Get users token by email or user name",
+//            description = "Retrieve user information based on their email address or username. " +
+//                    "This method decodes the user's JWT based on the provided email or username " +
+//                    "and returns a JWTResponse containing the user's JWT token.")
+//    @Observed(name = "user.login",
+//            contextualName = "user-login-method",
+//            lowCardinalityKeyValues = {
+//                    ObservabilityTags.LOGGABLE, "true",
+//            })
+//    public JwtResponse getUserByLogin(@RequestParam("userIdentifier") String userIdentifier) throws Exception {
+//
+//        // run code to get the user from the database
+//        JwtClaimsSet claims = userService.getJwtClaims(userIdentifier);
+//
+//        String jwt = jwtUtils.toJwtString(claims);
+//        return new JwtResponse(jwt);
+//    }
 
     @PostMapping(value = "/users", consumes = {"application/json"})
     @ResponseStatus(value = HttpStatus.CREATED)

--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/utils/JWTUtils.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/utils/JWTUtils.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
@@ -25,17 +26,6 @@ import java.util.stream.Collectors;
 @Component
 public class JWTUtils {
     private Logger logger = LoggerFactory.getLogger(JWTUtils.class);
-
-    @Autowired
-    private JwtDecoder jwtDecoder;
-
-    @Autowired
-    private JwtEncoder jwtEncoder;
-
-    public JwtDTO toJwtDTO(String jwtString) {
-        Jwt jwt = jwtDecoder.decode(jwtString);
-        return toJwtDTO(jwt);
-    }
 
     public JwtDTO toJwtDTO(Jwt jwt) {
         //implement the commented constructor in JwtDTO class
@@ -117,7 +107,7 @@ public class JWTUtils {
     }
 
 
-    private List<String> getAuthorities(JwtDTO jwtDTO) {
+    public List<String> getAuthorities(JwtDTO jwtDTO) {
         List<String> authoritiesMap = jwtDTO.getOrgAuthoritiesMap().entrySet().stream()
                 .flatMap(entry -> entry.getValue().orgAuthorities().stream().map(s -> s + ":" + entry.getKey().toString()))
                 .collect(Collectors.toList());
@@ -126,10 +116,14 @@ public class JWTUtils {
         return authoritiesMap;
     }
 
-    public String toJwtString(JwtDTO jwtDTO) {
-        var claims = toClaimsSet(jwtDTO);
-        return jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
-    }
+//    public String toJwtString(JwtDTO jwtDTO) {
+//        var claims = toClaimsSet(jwtDTO);
+//        return this.toJwtString(claims);
+//    }
+//
+//    public String toJwtString(JwtClaimsSet claims) {
+//        return gendoxJwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
+//    }
 
     private boolean verifyJWTSignature(String jwtString, RSAKey rsaKey) throws JOSEException, ParseException {
         SignedJWT jwt = SignedJWT.parse(jwtString);
@@ -146,21 +140,6 @@ public class JWTUtils {
     private boolean isTokenRevoked(String jwtString) {
         return false;
     }
-
-    // Method to check if token is valid
-//    public boolean isTokenValid(String jwtString, RSAKey rsaKey) {
-//        JWTClaimsSet claims = null;
-//        try {
-//            claims = toClaims(jwtString);
-//            return verifyJWTSignature(jwtString, rsaKey) &&
-//                    !isTokenExpired(claims.getExpirationTime()) &&
-//                    !isTokenRevoked(jwtString);
-//        } catch (JOSEException | ParseException e) {
-//            logger.error("Error while parsing JWT", e);
-//            return false;
-//        }
-//
-//    }
 
 
     public JWT getJWT(String jwtString) throws JOSEException, ParseException {

--- a/gendox-core-api/src/main/resources/application-dev.yml
+++ b/gendox-core-api/src/main/resources/application-dev.yml
@@ -38,6 +38,24 @@ spring:
   application:
     name: gendox-core-api
 
+
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://idp-dev.gendox.ctrlspace.dev/realms/gendox-idp-dev
+          jwk-set-uri: https://idp-dev.gendox.ctrlspace.dev/realms/gendox-idp-dev/protocol/openid-connect/certs
+
+
+
+keycloak:
+    base-url: https://idp-dev.gendox.ctrlspace.dev
+    token-uri: https://idp-dev.gendox.ctrlspace.dev/realms/gendox-idp-dev/protocol/openid-connect/token
+    realm: gendox-idp-dev
+    client-id: ${KEYCLOAK_CLIENT_ID}
+    client-secret: ${KEYCLOAK_CLIENT_SECRET}
+
 management:
   tracing:
     sampling:

--- a/gendox-core-api/src/main/resources/application-local.yml
+++ b/gendox-core-api/src/main/resources/application-local.yml
@@ -7,6 +7,7 @@ server:
 logging:
   level:
     dev.ctrlspace: DEBUG
+    org.springframework.security: INFO
     org.springframework: INFO
 #    This is how to change the micrometer tracing pattern, we'll use the default now
 #  pattern:
@@ -49,6 +50,24 @@ spring:
   application:
     name: gendox-core-api
 
+
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://idp-dev.gendox.ctrlspace.dev/realms/gendox-idp-dev
+          jwk-set-uri: https://idp-dev.gendox.ctrlspace.dev/realms/gendox-idp-dev/protocol/openid-connect/certs
+
+
+
+keycloak:
+    base-url: https://idp-dev.gendox.ctrlspace.dev
+    token-uri: https://idp-dev.gendox.ctrlspace.dev/realms/gendox-idp-dev/protocol/openid-connect/token
+    realm: gendox-idp-dev
+    client-id: ${KEYCLOAK_CLIENT_ID}
+    client-secret: ${KEYCLOAK_CLIENT_SECRET}
+
 management:
   tracing:
     sampling:
@@ -82,7 +101,7 @@ gendox:
   documents:
 #    upload-dir: s3://gendox.organization.documents.local
 #    upload-dir: file:c:\\Users\\sekas\\gendox-documents
-    upload-dir: file:C:\Users\Giannis\Desktop\gendox-files\test
+    upload-dir: file:c:\\Users\\sekas\\gendox-documents
 
 
     wordCount: 300
@@ -91,7 +110,7 @@ gendox:
 
   integrations:
     storage:
-      temporary: C:\Users\Giannis\Desktop\gendox-files\test\temporary_integration_files
+      temporary: c:\\Users\\sekas\\gendox-documents\\temporary_integration_files
 #      temporary: s3://gendox.organization.documents.local/gendox_wiki
 
   models:
@@ -160,6 +179,9 @@ discord:
 
   server:
     group-name: gendox-agents
+
+
+
 
 
 


### PR DESCRIPTION
Fix #123 Keycloak integration

- Add AuthorizationService interface to implement multiple IDPs
- Add default Keycloak implementation
- Implement custom JWT to hold the UserProfile
- Remove code that created and validated the self-issued gendox tokens
- Remove the /users/login API which implemented the mock login functionality
- Add implementation in the Discord adapter, to impersonate a user when a message is received from Discord