### PR TITLE
fix(dto): remove explicit type on policyvalue ColumnResult to let Hib…

### DIFF
--- a/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/model/dtos/MessageMetadataDTO.java
+++ b/gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/model/dtos/MessageMetadataDTO.java
@@ -40,7 +40,7 @@ import java.util.UUID;
                                 @ColumnResult(name = "documenttitle", type = String.class),
                                 @ColumnResult(name = "sectiontitle", type = String.class),
                                 @ColumnResult(name = "policytypename", type = String.class),
-                                @ColumnResult(name = "policyvalue", type = String[].class)
+                                @ColumnResult(name = "policyvalue")
                         }
                 )
         }


### PR DESCRIPTION


- Removed `type = Object[].class` from the @ColumnResult for `policyvalue` in MessageMetadataDTO