### PR TITLE
Add Claude Code Agent SDK setup with commands, hooks, and CI

### DIFF
--- a/.claude/commands/build-api.md
+++ b/.claude/commands/build-api.md
@@ -1,0 +1,5 @@
+Build the gendox-core-api Spring Boot backend.
+
+Run `cd gendox-core-api && mvn clean install -DskipTests` to build the API.
+
+If the build fails, analyze the error output, identify the root cause, and suggest a fix.

--- a/.claude/commands/build-frontend.md
+++ b/.claude/commands/build-frontend.md
@@ -1,0 +1,5 @@
+Build the gendox-frontend Next.js application.
+
+Run `cd gendox-frontend && yarn build` to build the frontend.
+
+If the build fails, analyze the error output, identify the root cause, and fix the issues. Pay attention to TypeScript errors, missing imports, and component prop mismatches.

--- a/.claude/commands/dev-up.md
+++ b/.claude/commands/dev-up.md
@@ -1,0 +1,13 @@
+Start the local development environment using Docker Compose.
+
+Run `docker-compose -f gendox-compose-scripts/dev-ci-installation/docker-compose.yml up -d` to start all services.
+
+Then check the status with `docker-compose -f gendox-compose-scripts/dev-ci-installation/docker-compose.yml ps`.
+
+Report which services are running and their health status.
+
+Service URLs:
+- API: http://localhost:8080/gendox/api/v1
+- Frontend: http://localhost:3000
+- Keycloak: https://localhost:8443
+- Database: localhost:5432

--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,24 @@
+Implement a GitHub issue and create a PR with the solution.
+
+The issue to implement: $ARGUMENTS
+
+Follow these steps:
+
+1. **Read the issue** — use `gh issue view <number>` to get the full description, labels, and comments
+2. **Analyze the requirements** — break down what needs to be done
+3. **Create a feature branch** — `git checkout -b feat/<short-description>` from main
+4. **Implement the solution** following Gendox patterns:
+   - Backend: Controller → Service → Repository layered architecture
+   - Frontend: Next.js pages + shadcn/ui components + Redux state
+   - Database: Flyway migrations for schema changes
+5. **Write Playwright e2e tests** for any new API endpoints:
+   - Create page objects in `gendox-e2e-tests/page-objects/apis/`
+   - Create test specs in `gendox-e2e-tests/tests/api-tests/`
+   - Follow the existing POM pattern (see other files for reference)
+   - Include auth setup with `keycloak.simpleUserLogin(request)`
+   - Test both success and error/unauthorized cases
+6. **Verify the build** — run `cd gendox-core-api && mvn clean install -DskipTests` and `cd gendox-frontend && yarn build`
+7. **Commit and push** the changes
+8. **Create a PR** with `gh pr create` referencing the issue (use "Closes #N" in the body)
+
+Always include e2e tests for new or modified API endpoints.

--- a/.claude/commands/list-issues.md
+++ b/.claude/commands/list-issues.md
@@ -1,0 +1,14 @@
+List open GitHub issues that can be worked on.
+
+Filter: $ARGUMENTS
+
+Run the appropriate command based on the filter:
+
+- If no filter: `gh issue list --state open --limit 20`
+- If a label is given: `gh issue list --state open --label "$ARGUMENTS" --limit 20`
+- If "mine" or "assigned": `gh issue list --state open --assignee @me --limit 20`
+- If "claude": `gh issue list --state open --label "claude" --limit 20`
+
+For each issue, show: number, title, labels, and assignee.
+
+Suggest which issues are good candidates for automated implementation (clear requirements, well-scoped, has acceptance criteria).

--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -1,0 +1,25 @@
+Create a new AI model provider adapter for Gendox.
+
+The user wants to integrate: $ARGUMENTS
+
+Follow the existing adapter implementation pattern:
+
+1. **Create DTOs** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/ai/engine/model/dtos/<provider>/`
+   - Request/Response classes matching the provider's API format
+
+2. **Create the service adapter** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/ai/engine/services/<provider>/aiengine/aiengine/`
+   - Implement `AiModelApiAdapterService` interface
+   - Support the relevant methods: `askCompletion`, `askEmbedding`, `askModeration`, `askRerank`
+   - Use `RestTemplate` for HTTP calls
+   - Add `@Component` with `@Qualifier` annotation
+
+3. **Create a response converter** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/ai/engine/converters/`
+   - Convert provider-specific response to generic `CompletionResponse`
+
+4. **Create config constants** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/ai/engine/utils/constants/`
+
+5. **Create a database migration** to insert the provider and models into `ai_model_providers` and `ai_models` tables
+
+6. **Reference existing adapters** for patterns:
+   - `OpenAiServiceAdapter.java` - most complete implementation (with tool use)
+   - `AnthropicAiServiceAdapter.java` - simpler implementation

--- a/.claude/commands/new-ai-tool.md
+++ b/.claude/commands/new-ai-tool.md
@@ -1,0 +1,20 @@
+Create a new AI tool for the Gendox agent system.
+
+The user wants to create: $ARGUMENTS
+
+Follow the existing tool implementation pattern:
+
+1. **Create the tool handler** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/ai/engine/tools/`
+   - Implement `AiToolHandler` interface
+   - Provide `getName()`, `getDescription()`, `getParametersSchema()`, and `execute()` methods
+   - Use `ToolExecutionContext` for accessing agent, message, and project context
+   - Add `@Component` annotation so it auto-registers with `AiToolRegistry`
+
+2. **Reference existing tools** for patterns:
+   - `ReadDocumentTool.java` - backend-executable tool example
+   - `AiToolHandler.java` - the interface to implement
+   - `AiToolRegistry.java` - how tools are registered and discovered
+
+3. **Create a database migration** to insert the tool definition into `ai_tools` table if it should be available by default
+
+4. **Test** the tool by verifying it appears in the tool registry and can be executed

--- a/.claude/commands/new-api-endpoint.md
+++ b/.claude/commands/new-api-endpoint.md
@@ -1,0 +1,30 @@
+Create a new REST API endpoint for Gendox.
+
+The user wants to create: $ARGUMENTS
+
+Follow the existing layered architecture pattern:
+
+1. **Controller** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/controller/`
+   - Use `@RestController` with `@RequestMapping("/gendox/api/v1/...")`
+   - Add `@PreAuthorize` for security
+   - Use proper HTTP methods and status codes
+   - Add request validation
+
+2. **Service** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/services/`
+   - Business logic layer
+   - Transaction management with `@Transactional`
+   - Throw appropriate exceptions from `GendoxException`
+
+3. **Repository** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/repositories/`
+   - Extend `JpaRepository`
+   - Use QueryDSL for complex queries with `@QuerydslPredicate`
+
+4. **DTOs** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/model/dtos/`
+   - Request/Response DTOs separate from entities
+
+5. **Converters** in `gendox-core-api/src/main/java/dev/ctrlspace/gendox/gendoxcoreapi/converters/`
+   - Entity ↔ DTO conversion
+
+6. **Frontend SDK** - Add the corresponding service method in `gendox-frontend/src/gendox-sdk/`
+
+Reference existing controllers and services for patterns.

--- a/.claude/commands/new-frontend-page.md
+++ b/.claude/commands/new-frontend-page.md
@@ -1,0 +1,29 @@
+Create a new frontend page for Gendox.
+
+The user wants to create: $ARGUMENTS
+
+Follow the existing Next.js + shadcn/ui architecture:
+
+1. **Page component** in `gendox-frontend/src/pages/gendox/`
+   - Use the file-system routing convention
+   - Wrap with appropriate layout (UserLayout or GendoxChatLayout)
+   - Add authentication guard if needed (OrganizationProjectGuard, PrivateRoute)
+
+2. **View components** in `gendox-frontend/src/views/pages/`
+   - Feature-based organization
+   - Use shadcn/ui components from `@/components/ui/`
+   - Use Tailwind CSS for styling with theme CSS variables
+   - Use `cn()` from `@/lib/utils` for conditional classes
+
+3. **State management** - if needed:
+   - Redux slice in `gendox-frontend/src/store/`
+   - Use `createAsyncThunk` for API calls
+   - Use `useSelector` and `useDispatch` hooks
+
+4. **API integration** in `gendox-frontend/src/gendox-sdk/`
+   - Add service methods for API calls
+   - Use the centralized API request config
+
+5. **Navigation** - Add entry in `gendox-frontend/src/navigation/vertical/`
+
+Use the Gendox color palette and shadcn/ui components. Ensure dark/light mode compatibility.

--- a/.claude/commands/new-migration.md
+++ b/.claude/commands/new-migration.md
@@ -1,0 +1,16 @@
+Create a new Flyway database migration file.
+
+The user wants to create a migration for: $ARGUMENTS
+
+Follow these steps:
+1. Check the latest migration version in `database/src/main/resources/db/migrations/gendox-core/` to determine the next version number
+2. Use the naming convention: `V[YYYYMMDD]_[HHMMSS]__Description.sql` (use today's date and current time)
+3. Create the migration file with proper SQL
+4. Follow existing migration patterns - check similar migrations for reference
+5. Include rollback considerations as SQL comments
+
+Important:
+- Use `gendox_core` schema
+- Use UUID primary keys with `uuid_generate_v4()` default
+- Reference existing tables and types from the schema
+- Add appropriate indexes for query patterns

--- a/.claude/commands/pr-from-issue.md
+++ b/.claude/commands/pr-from-issue.md
@@ -1,0 +1,32 @@
+Create a pull request that addresses a GitHub issue.
+
+Issue: $ARGUMENTS
+
+Steps:
+1. Fetch the issue details: `gh issue view <number>`
+2. Read all comments for additional context: `gh issue view <number> --comments`
+3. Analyze what changes are needed (backend, frontend, database, tests)
+4. Create a branch: `git checkout -b feat/<short-description>` from main
+5. Implement the changes following existing Gendox patterns
+6. Write Playwright e2e tests for any API changes
+7. Build and verify:
+   - `cd gendox-core-api && mvn clean install -DskipTests`
+   - `cd gendox-frontend && yarn build`
+8. Commit with a descriptive message
+9. Push and create a PR:
+   ```
+   gh pr create --title "Short description" --body "Closes #<number>
+
+   ## Summary
+   - What was done
+
+   ## Test plan
+   - [ ] E2e tests added/updated
+   - [ ] Build verified
+   "
+   ```
+
+Important:
+- Always reference the issue with "Closes #N" so it auto-closes on merge
+- Include e2e tests for API changes
+- Follow existing code patterns and conventions

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,12 @@
+Review the current changes for code quality, consistency, and potential issues.
+
+Run `git diff` to see all current changes, then analyze them for:
+
+1. **Code quality**: naming conventions, error handling, edge cases
+2. **Security**: SQL injection, XSS, command injection, exposed secrets, OWASP top 10
+3. **Consistency**: follows existing patterns, uses established conventions
+4. **Architecture**: proper layering, separation of concerns, no circular dependencies
+5. **Performance**: N+1 queries, unnecessary computations, missing indexes
+6. **Testing**: suggest tests that should be written for the changes
+
+Provide actionable feedback organized by severity (critical, warning, suggestion).

--- a/.claude/commands/test-api.md
+++ b/.claude/commands/test-api.md
@@ -1,0 +1,8 @@
+Run the gendox-core-api backend tests.
+
+Run `cd gendox-core-api && mvn test` to execute all unit tests.
+
+If any tests fail:
+1. Show the failing test names and error messages
+2. Identify the root cause
+3. Suggest or apply fixes

--- a/.claude/commands/test-e2e.md
+++ b/.claude/commands/test-e2e.md
@@ -1,0 +1,7 @@
+Run the Playwright end-to-end tests.
+
+Run `cd gendox-e2e-tests && npx playwright test --project=chromium $ARGUMENTS` to execute E2E tests.
+
+If $ARGUMENTS is empty, run all tests. Otherwise, use it as the test file or filter pattern.
+
+If tests fail, analyze the output, check for UI changes or API issues, and suggest fixes.

--- a/.claude/commands/write-e2e-tests.md
+++ b/.claude/commands/write-e2e-tests.md
@@ -1,0 +1,57 @@
+Write Playwright e2e tests for the specified feature or API endpoint.
+
+Target: $ARGUMENTS
+
+Follow the existing Gendox e2e test patterns:
+
+1. **Page Object (POM)** — Create or update in `gendox-e2e-tests/page-objects/apis/`
+   ```javascript
+   const config = require('../../tests.config');
+
+   const getResource = async (request, token, id) => {
+       const response = await request.get(
+           `${config.gendox.contextPath}/your-endpoint/${id}`,
+           {
+               headers: {
+                   'Authorization': 'Bearer ' + token,
+                   'Content-Type': 'application/json'
+               }
+           }
+       );
+       return response;
+   }
+
+   module.exports = { getResource }
+   ```
+
+2. **Test spec** — Create in `gendox-e2e-tests/tests/api-tests/`
+   ```javascript
+   const { test, expect } = require('@playwright/test');
+   const keycloak = require('../../page-objects/apis/keycloak');
+
+   test.describe('Feature API', () => {
+       let token;
+       test.beforeAll(async ({ request }) => {
+           const response = await keycloak.simpleUserLogin(request);
+           let body = await response.json();
+           token = body.access_token;
+           expect(response.ok()).toBeTruthy();
+       });
+
+       test('should ...', async ({ request }) => {
+           // test implementation
+       });
+   });
+   ```
+
+3. **Test coverage** — Include tests for:
+   - CRUD operations (GET, POST, PUT, DELETE)
+   - Pagination responses (`totalElements`, `content`)
+   - Authorization (admin vs non-admin)
+   - Validation errors (missing required fields → 400)
+   - Not found cases → 404
+   - Nested object assertions
+
+4. **Run tests** to verify: `cd gendox-e2e-tests && npx playwright test tests/api-tests/<your-spec>.spec.js --project=chromium`
+
+Reference existing tests in `gendox-e2e-tests/tests/api-tests/` for patterns.

--- a/.claude/hooks/stop-harness.sh
+++ b/.claude/hooks/stop-harness.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Stop hook: verification harness that runs when Claude finishes responding
+# Checks if modified files have obvious issues before the session ends
+# Exit 0 = ok, Exit 2 = block (ask Claude to fix)
+
+# Get list of modified files
+MODIFIED_FILES=$(git diff --name-only 2>/dev/null)
+
+if [ -z "$MODIFIED_FILES" ]; then
+  exit 0
+fi
+
+ERRORS=""
+
+# Check Java files for compilation issues (basic syntax)
+JAVA_FILES=$(echo "$MODIFIED_FILES" | grep '\.java$' || true)
+if [ -n "$JAVA_FILES" ]; then
+  for f in $JAVA_FILES; do
+    if [ -f "$f" ]; then
+      # Check for unmatched braces
+      OPEN=$(grep -o '{' "$f" | wc -l)
+      CLOSE=$(grep -o '}' "$f" | wc -l)
+      if [ "$OPEN" -ne "$CLOSE" ]; then
+        ERRORS="$ERRORS\nUnmatched braces in $f (open: $OPEN, close: $CLOSE)"
+      fi
+    fi
+  done
+fi
+
+# Check for accidentally committed secrets
+for f in $MODIFIED_FILES; do
+  if [ -f "$f" ]; then
+    if grep -qiE "(api_key|secret_key|password)\s*=\s*['\"][^'\"]{8,}" "$f" 2>/dev/null; then
+      # Exclude test/config files that legitimately reference these
+      if ! echo "$f" | grep -qE "(test|spec|example|sample|application\.yml|docker-compose)"; then
+        ERRORS="$ERRORS\nPossible hardcoded secret in $f"
+      fi
+    fi
+  fi
+done
+
+# Check for debug/console statements left in code
+for f in $MODIFIED_FILES; do
+  if [ -f "$f" ]; then
+    if echo "$f" | grep -qE '\.(js|ts|tsx|jsx)$'; then
+      if grep -n 'console\.log\|debugger' "$f" 2>/dev/null | head -3 | grep -q .; then
+        ERRORS="$ERRORS\nDebug statements found in $f"
+      fi
+    fi
+    if echo "$f" | grep -qE '\.java$'; then
+      if grep -n 'System\.out\.println\|\.printStackTrace()' "$f" 2>/dev/null | head -3 | grep -q .; then
+        ERRORS="$ERRORS\nDebug statements found in $f"
+      fi
+    fi
+  fi
+done
+
+if [ -n "$ERRORS" ]; then
+  echo -e "Stop harness found issues:$ERRORS" >&2
+  echo -e "\nPlease fix these before finishing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/validate-bash.sh
+++ b/.claude/hooks/validate-bash.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# PreToolUse hook: validate Bash commands before execution
+# Exit 0 = allow, Exit 2 = block
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Block destructive database operations
+if echo "$COMMAND" | grep -iqE "drop\s+(table|database|schema)|truncate\s+table"; then
+  echo "Blocked: destructive database operation. Use a Flyway migration instead." >&2
+  exit 2
+fi
+
+# Block force pushes
+if echo "$COMMAND" | grep -qE "git\s+push\s+.*--force|git\s+push\s+-f"; then
+  echo "Blocked: force push is not allowed. Use a regular push." >&2
+  exit 2
+fi
+
+# Block hard resets
+if echo "$COMMAND" | grep -qE "git\s+reset\s+--hard"; then
+  echo "Blocked: git reset --hard can destroy work. Use git stash or a soft reset." >&2
+  exit 2
+fi
+
+# Block recursive deletes on important dirs
+if echo "$COMMAND" | grep -qE "rm\s+-rf\s+(/|~|\.\.|gendox-core-api|gendox-frontend|database)"; then
+  echo "Blocked: recursive delete on protected directory." >&2
+  exit 2
+fi
+
+# Block credential file access
+if echo "$COMMAND" | grep -qE "cat\s+.*\.(env|pem|key)|echo.*ANTHROPIC_API_KEY|echo.*SECRET"; then
+  echo "Blocked: do not read or echo secrets/credentials." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/validate-file-edit.sh
+++ b/.claude/hooks/validate-file-edit.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# PreToolUse hook: validate file edits before execution
+# Exit 0 = allow, Exit 2 = block
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Block editing environment/secret files
+if echo "$FILE_PATH" | grep -qE "\.(env|pem|key)$|credentials\.json|secrets\."; then
+  echo "Blocked: cannot edit secret/credential files." >&2
+  exit 2
+fi
+
+# Block editing lock files directly
+if echo "$FILE_PATH" | grep -qE "(package-lock\.json|yarn\.lock|pom\.xml\.lock)$"; then
+  echo "Blocked: lock files should not be edited directly. Use the package manager." >&2
+  exit 2
+fi
+
+# Block editing Flyway migration files that are already applied (V prefix, not the latest)
+if echo "$FILE_PATH" | grep -qE "db/migrations/.*\.sql$"; then
+  BASENAME=$(basename "$FILE_PATH")
+  # Allow new migrations (created in this session), warn about existing ones
+  if [ -f "$FILE_PATH" ]; then
+    echo "Warning: editing an existing migration file. Only edit if it has not been applied to any environment." >&2
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,54 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "WebSearch",
+      "WebFetch"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(drop table*)",
+      "Bash(drop database*)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(*.pem)",
+      "Read(*.key)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/validate-bash.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/validate-file-edit.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/stop-harness.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,36 @@
+name: Claude Code Agent
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 25"
+          allowed_tools: "Bash,Read,Edit,Write,Glob,Grep,WebSearch,WebFetch"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened, assigned, labeled]
 
 permissions:
   contents: write
@@ -19,18 +19,45 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'claude'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: gendox-frontend/yarn.lock
+
+      - name: Install Playwright browsers
+        run: |
+          cd gendox-e2e-tests
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Install frontend dependencies
+        run: |
+          cd gendox-frontend
+          yarn install --frozen-lockfile
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 25"
+          claude_args: "--max-turns 50"
           allowed_tools: "Bash,Read,Edit,Write,Glob,Grep,WebSearch,WebFetch"
+        env:
+          MAVEN_OPTS: "-Xmx1024m"


### PR DESCRIPTION
## Summary
- **15 slash commands** for builds, tests, scaffolding, issue-to-PR workflow, and code review
- **PreToolUse hooks** that block destructive bash commands (force push, hard reset, DROP TABLE, rm -rf) and secret file edits (.env, .pem, .key)
- **Stop harness** that checks modified files for unmatched braces, leaked secrets, and leftover debug statements
- **GitHub Actions workflow** with full CI runtime (Java 21, Node 20, Playwright, yarn) — triggers on `@claude` mentions or `claude` label on issues

## Issue-to-PR workflow
1. Add the `claude` label to any issue → Claude picks it up automatically in CI
2. Or comment `@claude implement this` on any issue/PR
3. Claude reads the issue, implements the solution, writes Playwright e2e tests, and opens a PR

## Slash commands

| Command | Description |
|---------|-------------|
| `/implement-issue <number>` | Read a GitHub issue, implement it, write e2e tests, create PR |
| `/pr-from-issue <number>` | Create a PR that addresses a specific issue |
| `/list-issues [filter]` | List open issues (supports labels, `mine`, `claude`) |
| `/write-e2e-tests <feature>` | Write Playwright tests following Gendox POM pattern |
| `/new-api-endpoint <desc>` | Scaffold controller → service → repo → DTO → frontend SDK |
| `/new-frontend-page <desc>` | Create Next.js page with shadcn/ui + Redux |
| `/new-ai-tool <desc>` | Create AI agent tool (AiToolHandler) |
| `/new-adapter <provider>` | Create AI model provider adapter |
| `/new-migration <desc>` | Create Flyway migration with proper naming |
| `/build-api` | Build Spring Boot backend |
| `/build-frontend` | Build Next.js frontend |
| `/test-api` | Run backend unit tests |
| `/test-e2e [filter]` | Run Playwright e2e tests |
| `/dev-up` | Start Docker Compose dev environment |
| `/review` | Review git diff for quality, security, consistency |

## Hooks

| Hook | Type | What it does |
|------|------|-------------|
| `validate-bash.sh` | PreToolUse (Bash) | Blocks DROP TABLE, force push, hard reset, rm -rf on protected dirs, credential echoing |
| `validate-file-edit.sh` | PreToolUse (Edit/Write) | Blocks edits to .env, .pem, .key, lock files; warns on existing migrations |
| `stop-harness.sh` | Stop | Checks modified files for unmatched braces, hardcoded secrets, console.log/System.out.println |

## GitHub Actions CI setup
- **Triggers**: `@claude` in issue/PR comments, `claude` label on issues
- **Runtime**: Ubuntu with Java 21, Node 20, Playwright (Chromium), yarn
- **Timeout**: 60 minutes, 50 max turns
- **Tools**: Bash, Read, Edit, Write, Glob, Grep, WebSearch, WebFetch

## Setup required
1. Add `ANTHROPIC_API_KEY` to GitHub repo secrets (Settings → Secrets → Actions)
2. Create a `claude` label in the repo for issue-driven automation

## File structure
```
.claude/
├── settings.json
├── hooks/
│   ├── validate-bash.sh
│   ├── validate-file-edit.sh
│   └── stop-harness.sh
└── commands/
    ├── build-api.md          ├── new-adapter.md
    ├── build-frontend.md     ├── new-ai-tool.md
    ├── dev-up.md             ├── new-api-endpoint.md
    ├── implement-issue.md    ├── new-frontend-page.md
    ├── list-issues.md        ├── new-migration.md
    ├── pr-from-issue.md      ├── review.md
    ├── write-e2e-tests.md    ├── test-api.md
    └── test-e2e.md
.github/workflows/
└── claude-code.yml
```

## Test plan
- [ ] Run `/build-api` and `/build-frontend` commands in Claude Code
- [ ] Verify PreToolUse hooks block `rm -rf /`, `git push --force`, editing `.env`
- [ ] Verify stop harness catches `console.log` in JS and `System.out.println` in Java
- [ ] Add `ANTHROPIC_API_KEY` secret and create `claude` label
- [ ] Test `@claude` mention in a test issue
- [ ] Test `/implement-issue` and `/write-e2e-tests` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)